### PR TITLE
Fix the outdated <title> tag in post #3

### DIFF
--- a/lessons-3.html
+++ b/lessons-3.html
@@ -10,7 +10,7 @@
       gtag('config', 'UA-33085410-1');
     </script>
     <link rel="stylesheet" href="main.css">
-    <title> Lessons from Keith Rabois Essay 2: How to Interview an Executive </title>
+    <title> Lessons from Keith Rabois Essay 3: How to be an Effective Executive </title>
     <link rel='icon' href='favicon.ico' type='image/x-icon'/ >
   </head>
   <body>


### PR DESCRIPTION
Currently has the <title> from the last post: ```Lessons from Keith Rabois Essay 2: How to Interview an Executive```
Should read as edited in this commit: ```Lessons from Keith Rabois Essay 3: How to be an Effective Executive```